### PR TITLE
add react/jsx-no-bind to eslintrc.json

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -127,6 +127,7 @@
     "react/sort-comp": 2,
     "react/sort-prop-types": 2,
     "react/wrap-multilines": 2,
+		"react/jsx-no-bind": 1,
     "semi-spacing": 2,
     "semi": 2,
     "space-before-blocks": 2,


### PR DESCRIPTION
After reading this article http://benchling.engineering/performance-engineering-with-react/ and profiling a small react app, it can be up to half as slow to re-render when binding in `render` because React must remove the eventListener and then add a new eventListener to the DOM node.
